### PR TITLE
Allow adding arguments to php-unit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A systems hook that just runs `php -l` against stage files that have the `.php` 
   rev: 1.4.0
   hooks:
   - id: php-unit
+    args: [--debug]
 ```
 
 A bash script that will run the appropriate phpunit executable. It will assume
@@ -46,6 +47,8 @@ A bash script that will run the appropriate phpunit executable. It will assume
   - There is already a `phpunit.xml` in the root of the repo
 
 Note in its current state, it will run the whole PHPUnit test as along as `.php` file was committed.
+
+An `args` property in your hook declaration can be used for passing any valid PHPUnit arguments.
 
 ## php-cs
 

--- a/pre_commit_hooks/php-unit.sh
+++ b/pre_commit_hooks/php-unit.sh
@@ -9,7 +9,7 @@
 # - php
 #
 # Arguments
-# - None
+# See: https://phpunit.readthedocs.io/en/9.0/textui.html
 
 # Plugin title
 title="PHP Unit Task Runner"
@@ -26,8 +26,12 @@ source $DIR/helpers/formatters.sh
 source $DIR/helpers/welcome.sh
 source $DIR/helpers/locate.sh
 
-echo -e "${bldwht}Running command ${txtgrn} ${exec_command}"
-command_result=`eval $exec_command`
+command_args=$1
+command_to_run="${exec_command} ${command_args}"
+
+echo -e "${bldwht}Running command ${txtgrn} ${exec_command} ${command_args}"
+hr
+command_result=`eval $command_to_run`
 if [[ $command_result =~ FAILURES ]]
 then
     hr


### PR DESCRIPTION
Mimicking the work done for the `php-stan` hook, I have added support in `php-unit` for passing arguments.

This way, for example, you could run in a pre-push hook only the tests with a certain tag/group (e.g. the isolated ones).