### PR TITLE
Print offending files with `php-lint` and accommodate paths with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pre-commit scripts appropriate for *any* PHP project. These hooks are made as cu
 
 # Setup
 
-See (Adding pre-commit plugins to your project)[https://pre-commit.com/#adding-pre-commit-plugins-to-your-project]
+See [Adding pre-commit plugins to your project](https://pre-commit.com/#adding-pre-commit-plugins-to-your-project).
 
 # Supported Hooks
 
@@ -31,7 +31,6 @@ A bash script that runs `php -l` against stage files that are php. Assumes `php`
 A systems hook that just runs `php -l` against stage files that have the `.php` extension. Add the `args: [-s first]` in your `.pre-commit-config.yaml` to enable it to exit on the first error found.
 
 ## php-unit
-
 
 ```yaml
 - repo: https://github.com/digitalpulp/pre-commit-php.git
@@ -74,6 +73,7 @@ The `args` property in your hook declaration can be used for pass any valid PHP 
     files: \.(php)$
     args: [--standard=PSR1 -p]
 ```
+
 Similar pattern as the php-cs hook. A bash script that will run the appropriate [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) executable and will try to fix errors if it can using phpcbf.
 
 It will assume that there is a valid PHP Code Beautifier and Fixer executable at these locations, `vendor/bin/phpcbf`, `phpcbf` or `php phpcbf.phar` (in that exact order).
@@ -94,6 +94,7 @@ If you have multiple standards or a comma in your `args` property, escape the co
 To install PHP Codesniffer (phpcs & phpcbf), follow the [recommended steps here](https://github.com/squizlabs/PHP_CodeSniffer#installation).
 
 ## php-cs-fixer
+
 ```yaml
 -- repo: https://github.com/digitalpulp/pre-commit-php.git
    rev: 1.4.0
@@ -102,15 +103,14 @@ To install PHP Codesniffer (phpcs & phpcbf), follow the [recommended steps here]
     files: \.(php)$
     args: [--level=PSR2]
 ```
+
 Similar pattern as the php-cs hook. A bash script that will run the appropriate [PHP Coding Standards Fixer](http://cs.sensiolabs.org/) executable and to fix errors according to the configuration. It accepts all of the args from the `php-cs-fixer` command, in particular the `--level`, `--config`, and `--config-file` options.
 
 The tool will fail a build when it has made changes to the staged files. This allows a developer to do a `git diff` and examine the changes that it has made. Remember that you may omit this if needed with a `SKIP=php-cs-fixer git commit`.
 
 ## php-stan
 
-Adds the (PHPStan)[https://phpstan.org/] tool.
-
-
+Adds the [PHPStan](https://phpstan.org/) tool.
 
 ```yaml
 -- repo: https://github.com/digitalpulp/pre-commit-php.git

--- a/pre_commit_hooks/php-lint.sh
+++ b/pre_commit_hooks/php-lint.sh
@@ -54,12 +54,14 @@ while getopts ":s:" optname
     esac
   done
 
+shift "$arg_lookup_start"
+
 # Loop through the list of paths to run php lint against
 parse_error_count=0
-for path in ${*:$arg_lookup_start}
+for path in "$@"
 do
-    php -l "$path" 1> /dev/null
-    if [ $? -ne 0 ]; then
+    php -l "$path" | grep -Ev '^No syntax errors detected in '
+    if [ ${PIPESTATUS[0]} -ne 0 ]; then
 #        echo "PHP Parse errors were detected" >&2
         parse_error_count=$[$parse_error_count +1]
         php_errors_found=true


### PR DESCRIPTION
Fixes #18 and #22.
Includes some minor `README.md` cleanup.